### PR TITLE
Allow setting additional class for new terminal line

### DIFF
--- a/src/vtortola.ng-terminal.js
+++ b/src/vtortola.ng-terminal.js
@@ -437,7 +437,7 @@
                                     for (var i = 0; i < newValue.text.length; i++) {
                                         var line = document.createElement('pre');
                                         line.textContent = newValue.output?'  ':'';
-                                        line.className = 'terminal-line';
+                                        line.className = 'terminal-line' + newValue.className ? ' ' + newValue.className : '';
                                         line.textContent += newValue.text[i];
                                         results[0].appendChild(line)
                                     }


### PR DESCRIPTION
Through the property className in the broadcast command 'terminal-output' an additional class can be specified which allows e.g. coloured output.

Example:
 $scope.$broadcast('terminal-output', {
                              output: true,
                              text: [ res.output ],
                              className: 'bg-danger',
                              breakLine: true
                       });