### PR TITLE
Remove extra whitespace on first line of terminal output

### DIFF
--- a/src/vtortola.ng-terminal.js
+++ b/src/vtortola.ng-terminal.js
@@ -436,7 +436,6 @@
                                 else {
                                     for (var i = 0; i < newValue.text.length; i++) {
                                         var line = document.createElement('pre');
-                                        line.textContent = newValue.output?'  ':'';
                                         line.className = 'terminal-line';
                                         line.textContent += newValue.text[i];
                                         results[0].appendChild(line)


### PR DESCRIPTION
With every valid line 2 extra whitespaces are prepended to the actual output. If this is wanted by the user the output should aready be provided by the user with that extra whitespace. Otherwise there is no way to disable this behaviour..