### PR TITLE
Allow setting additional class for new terminal line

### DIFF
--- a/src/vtortola.ng-terminal.js
+++ b/src/vtortola.ng-terminal.js
@@ -438,6 +438,8 @@
                                         var line = document.createElement('pre');
                                         line.textContent = newValue.output?'  ':'';
                                         line.className = 'terminal-line';
+                                        if (newValue.className)
+                                            line.className += " " + newValue.className;
                                         line.textContent += newValue.text[i];
                                         results[0].appendChild(line)
                                     }


### PR DESCRIPTION
Through the property className in the broadcast command 'terminal-output' an additional class can be specified which allows e.g. coloured output.

Example:
$scope.$broadcast('terminal-output', {
output: true,
text: [ res.output ],
className: 'bg-danger',
breakLine: true
});